### PR TITLE
Use MSVCRT as default C runtime for mingw v12

### DIFF
--- a/scripts/001-headers-install-x86.sh
+++ b/scripts/001-headers-install-x86.sh
@@ -23,7 +23,8 @@ cd    build-x86-headers
 # Configure the headers. Explanations of the options will come after configure.
 ../mingw-w64-headers/configure --prefix=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686/i686-w64-mingw32 \
                                --enable-sdk=all                                                           \
-                               --host=i686-w64-mingw32
+                               --host=i686-w64-mingw32                                                    \
+                               --with-default-msvcrt=msvcrt
 
 # --prefix=/opt/*: This switch will install the files into that directory.
 # --enable-sdk=all: Installs all of the headers for MinGW.

--- a/scripts/004-mingw-x86.sh
+++ b/scripts/004-mingw-x86.sh
@@ -18,8 +18,9 @@ cd       mingw-w64-v$VERSION
 
 # Configure the package. Explanations of the options will come after configure.
 ./configure --prefix=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686/i686-w64-mingw32 \
-            --with-sysroot=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686 \
-            --host=i686-w64-mingw32                                         &&
+            --with-sysroot=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686            \
+            --host=i686-w64-mingw32                                                    \
+            --with-default-msvcrt=msvcrt                                               &&
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.

--- a/scripts/005-mingw-winpthreads-x86.sh
+++ b/scripts/005-mingw-winpthreads-x86.sh
@@ -19,8 +19,9 @@ cd       mingw-w64-v$VERSION/mingw-w64-libraries/winpthreads
 
 # Configure the package. Explanations of the options will come after configure.
 ./configure --prefix=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686/i686-w64-mingw32 \
-            --with-sysroot=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686 \
-            --host=i686-w64-mingw32                                         &&
+            --with-sysroot=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-i686            \
+            --host=i686-w64-mingw32                                                    \
+            --with-default-msvcrt=msvcrt                                               &&
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.

--- a/scripts/007-headers-install-x86_64.sh
+++ b/scripts/007-headers-install-x86_64.sh
@@ -22,8 +22,9 @@ cd    build-x86_64-headers
 
 # Configure the headers. Explanations of the options will come after configure.
 ../mingw-w64-headers/configure --prefix=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64/x86_64-w64-mingw32 \
-                               --enable-sdk=all                                                           \
-                               --host=x86_64-w64-mingw32
+                               --enable-sdk=all                                                               \
+                               --host=x86_64-w64-mingw32                                                      \
+                               --with-default-msvcrt=msvcrt
 
 # --prefix=/opt/*: This switch will install the files into that directory.
 # --enable-sdk=all: Installs all of the headers for MinGW.

--- a/scripts/010-mingw-x86_64.sh
+++ b/scripts/010-mingw-x86_64.sh
@@ -18,8 +18,9 @@ cd       mingw-w64-v$VERSION
 
 # Configure the package. Explanations of the options will come after configure.
 ./configure --prefix=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64/x86_64-w64-mingw32 \
-            --with-sysroot=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64 \
-            --host=x86_64-w64-mingw32                                         &&
+            --with-sysroot=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64              \
+            --host=x86_64-w64-mingw32                                                      \
+            --with-default-msvcrt=msvcrt                                                   &&
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.

--- a/scripts/011-mingw-winpthreads-x86_64.sh
+++ b/scripts/011-mingw-winpthreads-x86_64.sh
@@ -19,8 +19,9 @@ cd       mingw-w64-v$VERSION/mingw-w64-libraries/winpthreads
 
 # Configure the package. Explanations of the options will come after configure.
 ./configure --prefix=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64/x86_64-w64-mingw32 \
-            --with-sysroot=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64 \
-            --host=x86_64-w64-mingw32                                         &&
+            --with-sysroot=/opt/gcc-14.2-binutils-2.43.1-mingw-v12.0.0-x86_64              \
+            --host=x86_64-w64-mingw32                                                      \
+            --with-default-msvcrt=msvcrt                                                   &&
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.


### PR DESCRIPTION
This fixes LegacyUpdateNSIS.dll failing to load on systems without the Universal C runtime (Windows 8.1 and older by default) as built by the CI. mingw-w64 v12 and newer uses the UCRT by default instead of MSVCRT used by previous versions. This change switches back to using MSVCRT as the default C runtime.

Fixes https://github.com/LegacyUpdate/LegacyUpdate/issues/319 on Windows XP - Windows 7.

See https://github.com/mingw-w64/mingw-w64/blob/master/mingw-w64-doc/howto-build/ucrt-vs-msvcrt.txt for more details.