### PR TITLE
Binutils scripts: Remove --disable-multilib.

### DIFF
--- a/scripts/002-binutils-x86.sh
+++ b/scripts/002-binutils-x86.sh
@@ -22,7 +22,6 @@ cd    build
 # First we'll configure Binutils.
 ../configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686       \
              --target=i686-w64-mingw32                                     \
-             --disable-multilib                                            \
              --disable-nls                                                 \
              --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686 \
              --disable-werror                                              &&
@@ -31,8 +30,6 @@ cd    build
 # --prefix=/opt/*: This switch will install the files into that directory.
 # --target=i686-w64-mingw32: This outputs files targeting the i686 version
 #                            of MinGW.
-# --disable-multilib: This switch disables multilib support. We don't need it
-#                     here, and we'll get a broken toolchain if we enable it.
 # --disable-nls:      This switch disables installing files that allow for
 #                     diagnostic output in other language than English.
 # --disable-werror:   This switch tells the build system to not treat warnings
@@ -48,7 +45,6 @@ sudo make install
 
 # Remove an unnecessary library
 sudo rm -v /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/lib/bfd-plugins/libdep.so
-
 
 # GCC requires a symlink of 'mingw' to be a mirror of the i686-w64-mingw32
 # directory, and it needs to be in the same root.

--- a/scripts/008-binutils-x86_64.sh
+++ b/scripts/008-binutils-x86_64.sh
@@ -22,7 +22,6 @@ cd    build
 # First we'll configure Binutils.
 ../configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64       \
              --target=x86_64-w64-mingw32                                     \
-             --disable-multilib                                              \
              --disable-nls                                                   \
              --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64 \
              --disable-werror                                                &&
@@ -31,8 +30,6 @@ cd    build
 # --prefix=/opt/*: This switch will install the files into that directory.
 # --target=x86_64-w64-mingw32: This outputs files targeting the x86_64 version
 #                              of MinGW.
-# --disable-multilib: This switch disables multilib support. We don't need it
-#                     here, and we'll get a broken toolchain if we enable it.
 # --disable-nls:      This switch disables installing files that allow for
 #                     diagnostic output in other language than English.
 # --disable-werror:   This switch tells the build system to not treat warnings


### PR DESCRIPTION
While Binutils shares the same build system as GCC, Binutils doesn't actually use the multilib options at all. While the flag or lack thereof doesn't actually cause a build failure, it is a useless parameter that doesnt't need to get passed. It's better to just have it removed.

GCC does make use of the flag passed to that build system and does really matter, which is why this PR doesn't mess with that. That param should remain.

Big thanks for Xi Ruoyao from the Linux From Scratch project making it known. It has been decently far out. Decided to check the scripts of this project again and noticed the flags are still here, so this PR cleans things up a little bit to only have what we need.