### PR TITLE
MinGW-w64 Scripts: Only build for the target.

### DIFF
--- a/scripts/004-mingw-x86.sh
+++ b/scripts/004-mingw-x86.sh
@@ -20,13 +20,17 @@ cd       mingw-w64-v$VERSION
 ./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/i686-w64-mingw32 \
             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686            \
             --host=i686-w64-mingw32                                                  \
+            --disable-lib64                                                          \
             --with-default-msvcrt=msvcrt                                             &&
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.
-# --host=i686-w64-mingw32: This uses the cross compiler that we just built.
 # --with-sysroot: This switch tells the build system to treat /opt/[...] as
 #                 the root directory.
+# --host=i686-w64-mingw32: This uses the cross compiler that we just built.
+# --disable-lib64: This switch forces the build system to disable building for
+#                  the opposite architecture along with the current one being
+#                  targetted.
 
 make -j4 &&
 

--- a/scripts/005-mingw-winpthreads-x86.sh
+++ b/scripts/005-mingw-winpthreads-x86.sh
@@ -21,13 +21,17 @@ cd       mingw-w64-v$VERSION/mingw-w64-libraries/winpthreads
 ./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/i686-w64-mingw32 \
             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686            \
             --host=i686-w64-mingw32                                                  \
+            --disable-lib64                                                          \
             --with-default-msvcrt=msvcrt                                             &&
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.
-# --host=i686-w64-mingw32: This uses the cross compiler that we just built.
 # --with-sysroot: This switch tells the build system to treat /opt/[...] as
 #                 the root directory.
+# --host=i686-w64-mingw32: This uses the cross compiler that we just built.
+# --disable-lib64: This switch forces the build system to disable building for
+#                  the opposite architecture along with the current one being
+#                  targetted.
 
 make -j4 &&
 

--- a/scripts/010-mingw-x86_64.sh
+++ b/scripts/010-mingw-x86_64.sh
@@ -20,13 +20,17 @@ cd       mingw-w64-v$VERSION
 ./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/x86_64-w64-mingw32 \
             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64              \
             --host=x86_64-w64-mingw32                                                    \
+            --disable-lib32                                                              \
             --with-default-msvcrt=msvcrt                                                 &&
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.
-# --host=x86_64-w64-mingw32: This uses the cross compiler that we just built.
 # --with-sysroot: This switch tells the build system to treat /opt/[...] as
 #                 the root directory.
+# --host=x86_64-w64-mingw32: This uses the cross compiler that we just built.
+# --disable-lib32: This switch forces the build system to disable building for
+#                  the opposite architecture along with the current one being
+#                  targetted.
 
 make -j4 &&
 

--- a/scripts/011-mingw-winpthreads-x86_64.sh
+++ b/scripts/011-mingw-winpthreads-x86_64.sh
@@ -21,13 +21,17 @@ cd       mingw-w64-v$VERSION/mingw-w64-libraries/winpthreads
 ./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/x86_64-w64-mingw32 \
             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64              \
             --host=x86_64-w64-mingw32                                                    \
+            --disable-lib32                                                              \
             --with-default-msvcrt=msvcrt                                                 &&
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.
-# --host=x86_64-w64-mingw32: This uses the cross compiler that we just built.
 # --with-sysroot: This switch tells the build system to treat /opt/[...] as
 #                 the root directory.
+# --host=x86_64-w64-mingw32: This uses the cross compiler that we just built.
+# --disable-lib32: This switch forces the build system to disable building for
+#                  the opposite architecture along with the current one being
+#                  targetted.
 
 make -j4 &&
 


### PR DESCRIPTION
This commit/PR forces the build system of MinGW-w64 to disable building for an architecture that is not the target. While this commit forces the build system to not do so on i686-w64-mingw32, it isn't strictly necessary, but may be needed in the future.

As for x86_64-w64-mingw32, what happens is for the C runtime section of the package is it builds for lib and lib32. Since we don't want multilib, the existence of the lib32 libraries is useless and takes up about 120M in the extracted tarball hosted on the Linux From Scratch website. Future proofing has been done for Winpthreads, as while the flag is not needed for Winpthreads, it can end up in the future building lib32 static libraries.

All in all, this commit will shave off 126M from 1579M, resulting in a new total size being 1453M, and with the future proofing should keep it at around that size, MinGW-w64 updates permitting.

For a future note, unrelated to this commit, we should also explain the `--with-default-msvcrt=msvcrt` parameter does in the build scripts. I can make a future PR pretty soon that does so, as well as making sure the options appear in the right order.