### PR TITLE
scripts: Reorganize option explanations.

### DIFF
--- a/scripts/001-headers-install-x86.sh
+++ b/scripts/001-headers-install-x86.sh
@@ -21,10 +21,11 @@ mkdir build-x86-headers
 cd    build-x86-headers
 
 # Configure the headers. Explanations of the options will come after configure.
-../mingw-w64-headers/configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/i686-w64-mingw32 \
-                               --enable-sdk=all                                                         \
-                               --host=i686-w64-mingw32                                                  \
-                               --with-default-msvcrt=msvcrt
+../mingw-w64-headers/configure                                             \
+  --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/i686-w64-mingw32 \
+  --enable-sdk=all                                                         \
+  --host=i686-w64-mingw32                                                  \
+  --with-default-msvcrt=msvcrt
 
 # --prefix=/opt/*: This switch will install the files into that directory.
 # --enable-sdk=all: Installs all of the headers for MinGW.

--- a/scripts/002-binutils-x86.sh
+++ b/scripts/002-binutils-x86.sh
@@ -32,10 +32,10 @@ cd    build
 #                            of MinGW.
 # --disable-nls:      This switch disables installing files that allow for
 #                     diagnostic output in other language than English.
-# --disable-werror:   This switch tells the build system to not treat warnings
-#                     as errors.
 # --with-sysroot:     This switch tells the build system to treat /opt/[...] as
 #                     the root directory.
+# --disable-werror:   This switch tells the build system to not treat warnings
+#                     as errors.
 
 # Next, we'll compile Binutils.
 make -j4 &&

--- a/scripts/003-gcc-static-x86.sh
+++ b/scripts/003-gcc-static-x86.sh
@@ -45,19 +45,17 @@ cd    build
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.
+# --with-sysroot:            This switch tells the build system to treat
+#                            /opt/[...] as the root directory.
 # --target=i686-w64-mingw32: This switch tells the compiler to target the Win32
 #                            architecture.
 # --enable-languages=c,c++:  We only need the C and C++ languages to be built.
 # --disable-shared:          Install a static version of GCC since we don't have
 #                            the MinGW C Runtime yet.
-# --disable-threads:         Disable threading support as we don't have a
-#                            threading library just yet.
 # --disable-multilib:        Disable multilib support since it's not necessary
 #                            here and causes problems.
-# --with-native-system-header-dir: This switch tells GCC to use the headers
-#                            installed by this directory when compiling itself.
-# --with-sysroot:            This switch tells the build system to treat
-#                            /opt/[...] as the root directory.
+# --disable-threads:         Disable threading support as we don't have a
+#                            threading library just yet.
 
 # Compile the static version of GCC.
 make all-gcc -j4 &&

--- a/scripts/004-mingw-x86.sh
+++ b/scripts/004-mingw-x86.sh
@@ -31,6 +31,12 @@ cd       mingw-w64-v$VERSION
 # --disable-lib64: This switch forces the build system to disable building for
 #                  the opposite architecture along with the current one being
 #                  targetted.
+# --with-default-msvcrt: Selects the default Visual C++ Runtime as the
+#                        Microsoft Visual C++ Runtime version instead of the
+#                        Universal C++ Runtime (which is only compatible with
+#                        more recent versions of Windows. For LegacyUpdate, we
+#                        need support for Windows 2000 at the earliest).
+#
 
 make -j4 &&
 

--- a/scripts/005-mingw-winpthreads-x86.sh
+++ b/scripts/005-mingw-winpthreads-x86.sh
@@ -32,6 +32,11 @@ cd       mingw-w64-v$VERSION/mingw-w64-libraries/winpthreads
 # --disable-lib64: This switch forces the build system to disable building for
 #                  the opposite architecture along with the current one being
 #                  targetted.
+# --with-default-msvcrt: Selects the default Visual C++ Runtime as the
+#                        Microsoft Visual C++ Runtime version instead of the
+#                        Universal C++ Runtime (which is only compatible with
+#                        more recent versions of Windows. For LegacyUpdate, we
+#                        need support for Windows 2000 at the earliest).
 
 make -j4 &&
 

--- a/scripts/006-gcc-x86.sh
+++ b/scripts/006-gcc-x86.sh
@@ -53,12 +53,17 @@ cd    build
 #                            use them.
 # --disable-multilib:        Disable multilib support since it's not necessary
 #                            here and causes problems.
-# --enable-threads=posix:    This switch allows MinGW to use the winpthreads
-#                            library installed by the last package.
 # --with-{arch,tune}=i486:   This switch tells the build system to default to
 #                            generating code for i486. This is so that we can
 #                            guarantee that whatever code gets output will run
 #                            on this CPU.
+# --disable-bootstrap: This switch explictly disables performing the bootstrap
+#                      process in GCC. The process builds several stages, with
+#                      previous stages building the following stages. We don't
+#                      need the benefits of performing this process and it
+#                      saves time.
+# --enable-threads=posix:    This switch allows MinGW to use the winpthreads
+#                            library installed by the last package.
 # --with-sysroot:            This switch tells the build system to treat
 #                            /opt/[...] as the root directory.
 

--- a/scripts/007-headers-install-x86_64.sh
+++ b/scripts/007-headers-install-x86_64.sh
@@ -21,10 +21,11 @@ mkdir build-x86_64-headers
 cd    build-x86_64-headers
 
 # Configure the headers. Explanations of the options will come after configure.
-../mingw-w64-headers/configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/x86_64-w64-mingw32 \
-                               --enable-sdk=all                                                             \
-                               --host=x86_64-w64-mingw32                                                    \
-                               --with-default-msvcrt=msvcrt
+../mingw-w64-headers/configure                                                 \
+  --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/x86_64-w64-mingw32 \
+  --enable-sdk=all                                                             \
+  --host=x86_64-w64-mingw32                                                    \
+  --with-default-msvcrt=msvcrt
 
 # --prefix=/opt/*: This switch will install the files into that directory.
 # --enable-sdk=all: Installs all of the headers for MinGW.

--- a/scripts/008-binutils-x86_64.sh
+++ b/scripts/008-binutils-x86_64.sh
@@ -32,10 +32,10 @@ cd    build
 #                              of MinGW.
 # --disable-nls:      This switch disables installing files that allow for
 #                     diagnostic output in other language than English.
-# --disable-werror:   This switch tells the build system to not treat warnings
-#                     as errors.
 # --with-sysroot:     This switch tells the build system to treat /opt/[...] as
 #                     the root directory.
+# --disable-werror:   This switch tells the build system to not treat warnings
+#                     as errors.
 
 # Next, we'll compile Binutils.
 make -j4 &&

--- a/scripts/009-gcc-static-x86_64.sh
+++ b/scripts/009-gcc-static-x86_64.sh
@@ -45,19 +45,17 @@ cd    build
 
 # --- Descriptions go here ---
 # --prefix=/opt/*: This switch will install the files into that directory.
+# --with-sysroot:            This switch tells the build system to treat
+#                            /opt/[...] as the root directory.
 # --target=x86_64-w64-mingw32: This switch tells the compiler to target the Win32
 #                              architecture.
 # --enable-languages=c,c++:  We only need the C and C++ languages to be built.
 # --disable-shared:          Install a static version of GCC since we don't have
 #                            the MinGW C Runtime yet.
-# --disable-threads:         Disable threading support as we don't have a
-#                            threading library just yet.
 # --disable-multilib:        Disable multilib support since it's not necessary
 #                            here and causes problems.
-# --with-native-system-header-dir: This switch tells GCC to use the headers
-#                            installed by this directory when compiling itself.
-# --with-sysroot:            This switch tells the build system to treat
-#                            /opt/[...] as the root directory.
+# --disable-threads:         Disable threading support as we don't have a
+#                            threading library just yet.
 
 # Compile the static version of GCC.
 make all-gcc -j4 &&

--- a/scripts/010-mingw-x86_64.sh
+++ b/scripts/010-mingw-x86_64.sh
@@ -31,6 +31,11 @@ cd       mingw-w64-v$VERSION
 # --disable-lib32: This switch forces the build system to disable building for
 #                  the opposite architecture along with the current one being
 #                  targetted.
+# --with-default-msvcrt: Selects the default Visual C++ Runtime as the
+#                        Microsoft Visual C++ Runtime version instead of the
+#                        Universal C++ Runtime (which is only compatible with
+#                        more recent versions of Windows. For LegacyUpdate, we
+#                        need support for Windows 2000 at the earliest).
 
 make -j4 &&
 

--- a/scripts/011-mingw-winpthreads-x86_64.sh
+++ b/scripts/011-mingw-winpthreads-x86_64.sh
@@ -32,6 +32,11 @@ cd       mingw-w64-v$VERSION/mingw-w64-libraries/winpthreads
 # --disable-lib32: This switch forces the build system to disable building for
 #                  the opposite architecture along with the current one being
 #                  targetted.
+# --with-default-msvcrt: Selects the default Visual C++ Runtime as the
+#                        Microsoft Visual C++ Runtime version instead of the
+#                        Universal C++ Runtime (which is only compatible with
+#                        more recent versions of Windows. For LegacyUpdate, we
+#                        need support for Windows 2000 at the earliest).
 
 make -j4 &&
 

--- a/scripts/012-gcc-x86_64.sh
+++ b/scripts/012-gcc-x86_64.sh
@@ -51,6 +51,11 @@ cd    build
 #                            use them.
 # --disable-multilib:        Disable multilib support since it's not necessary
 #                            here and causes problems.
+# --disable-bootstrap: This switch explictly disables performing the bootstrap
+#                      process in GCC. The process builds several stages, with
+#                      previous stages building the following stages. We don't
+#                      need the benefits of performing this process and it
+#                      saves time.
 # --enable-threads=posix:    This switch allows MinGW to use the winpthreads
 #                            library installed by the last package.
 # --with-sysroot:            This switch tells the build system to treat


### PR DESCRIPTION
This is a nonessential commit just focusing on ensuring the option explanations come at the right order. It also removes some option explanations that explainn options that aren't in the scripts. Lastly, it shortens the line length of the MinGW-w64 headers scripts as they were pretty long beforehand.

I am open to any requests!