### PR TITLE
scripts: Add variables.in. Fixes #5.

### DIFF
--- a/scripts/001-headers-install-x86.sh
+++ b/scripts/001-headers-install-x86.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # The first package that we need to install is the MinGW Headers. These headers
 # contain an implementation of the Win32 API.
 
-VERSION=13.0.0
 ARCHITECTURE=x86
-PACKAGE=mingw64-$ARCHITECTURE-headers-$VERSION
+PACKAGE=mingw64-$ARCHITECTURE-headers-$MINGW_HEADER_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Extract the tarball and change into the directory.
-tar -xvf ../mingw-w64-v$VERSION.tar.bz2
-cd          mingw-w64-v$VERSION
+tar -xvf ../mingw-w64-v$MINGW_HEADER_V.tar.bz2
+cd          mingw-w64-v$MINGW_HEADER_V
 
 # The source requires that we build it outside of the source tree. We'll work
 # around this by creating a separete directory and changing into it.
@@ -21,13 +21,13 @@ mkdir build-x86-headers
 cd    build-x86-headers
 
 # Configure the headers. Explanations of the options will come after configure.
-../mingw-w64-headers/configure                                             \
-  --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/i686-w64-mingw32 \
-  --enable-sdk=all                                                         \
-  --host=i686-w64-mingw32                                                  \
+../mingw-w64-headers/configure              \
+  --prefix=$MINGW_OPT-i686/i686-w64-mingw32 \
+  --enable-sdk=all                          \
+  --host=i686-w64-mingw32                   \
   --with-default-msvcrt=msvcrt
 
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --enable-sdk=all: Installs all of the headers for MinGW.
 # --host=i686-w64-mingw32: Builds files for the i686 version of MinGW.
 # --with-default-msvcrt: Selects the default Visual C++ Runtime as the

--- a/scripts/002-binutils-x86.sh
+++ b/scripts/002-binutils-x86.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs Binutils, which includes a linker and support programs.
 
-VERSION=2.44
 ARCHITECTURE=x86
-PACKAGE=mingw64-$ARCHITECTURE-binutils-$VERSION
+PACKAGE=mingw64-$ARCHITECTURE-binutils-$BINUTILS_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Extract the tarball and change into the directory.
-tar -xvf ../binutils-$VERSION.tar.xz
-cd       binutils-$VERSION
+tar -xvf ../binutils-$BINUTILS_V.tar.xz
+cd          binutils-$BINUTILS_V
 
 # This project needs to be built outside of it's source tree. We'll accomodate
 # that by making a new directory and changing into it.
@@ -20,14 +20,14 @@ mkdir build
 cd    build
 
 # First we'll configure Binutils.
-../configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686       \
-             --target=i686-w64-mingw32                                     \
-             --disable-nls                                                 \
-             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686 \
-             --disable-werror                                              &&
+../configure --prefix=$MINGW_OPT-i686       \
+             --target=i686-w64-mingw32      \
+             --disable-nls                  \
+             --with-sysroot=$MINGW_OPT-i686 \
+             --disable-werror              &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --target=i686-w64-mingw32: This outputs files targeting the i686 version
 #                            of MinGW.
 # --disable-nls:      This switch disables installing files that allow for
@@ -44,10 +44,10 @@ make -j4 &&
 sudo make install
 
 # Remove an unnecessary library
-sudo rm -v /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/lib/bfd-plugins/libdep.so
+sudo rm -v $MINGW_OPT-i686/lib/bfd-plugins/libdep.so
 
 # GCC requires a symlink of 'mingw' to be a mirror of the i686-w64-mingw32
 # directory, and it needs to be in the same root.
-cd /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686
+cd $MINGW_OPT-i686
 sudo ln -sfv ./i686-w64-mingw32 ./mingw
 sudo ln -sfv ./mingw/include include

--- a/scripts/003-gcc-static-x86.sh
+++ b/scripts/003-gcc-static-x86.sh
@@ -1,50 +1,48 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs a static version of GCC. This is needed because we do
 # not have a copy of the MinGW C Runtime installed yet, but we still need a
 # way to compile it.
 
-VERSION=15.1.0
 ARCHITECTURE=x86
-PACKAGE=mingw64-$ARCHITECTURE-gcc-static-$VERSION
-GMP_VERSION=6.3.0
-MPFR_VERSION=4.2.2
-MPC_VERSION=1.3.1
+PACKAGE=mingw64-$ARCHITECTURE-gcc-static-$GCC_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Make sure that we use our new utilities from binutils
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/bin:$PATH
+export PATH=$MINGW_OPT-i686/bin:$PATH
 
 # Extract the tarball and change into the directory.
-tar -xvf ../gcc-$VERSION.tar.xz
-cd       gcc-$VERSION
+tar -xvf ../gcc-$GCC_V.tar.xz
+cd          gcc-$GCC_V
 
 # Building GCC requires GMP, MPFR, and MPC. Let's have the build system build them.
-tar -xvf ../../gmp-$GMP_VERSION.tar.xz
-tar -xvf ../../mpc-$MPC_VERSION.tar.gz
-tar -xvf ../../mpfr-$MPFR_VERSION.tar.xz
-mv -v gmp-$GMP_VERSION/ gmp
-mv -v mpfr-$MPFR_VERSION/ mpfr/
-mv -v mpc-$MPC_VERSION/ mpc/
+tar -xvf ../../gmp-$GMP_V.tar.xz
+tar -xvf ../../mpc-$MPC_V.tar.gz
+tar -xvf ../../mpfr-$MPFR_V.tar.xz
+mv -v gmp-$GMP_V   gmp
+mv -v mpfr-$MPFR_V mpfr
+mv -v mpc-$MPC_V   mpc
 
 # Create a directory outside of the source tree.
 
 mkdir build
 cd    build
 
-../configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686       \
-             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686 \
-             --target=i686-w64-mingw32                                     \
-             --enable-languages=c,c++                                      \
-             --disable-shared                                              \
-             --disable-multilib                                            \
-             --disable-threads                                             &&
+../configure --prefix=$MINGW_OPT-i686       \
+             --with-sysroot=$MINGW_OPT-i686 \
+             --target=i686-w64-mingw32      \
+             --enable-languages=c,c++       \
+             --disable-shared               \
+             --disable-multilib             \
+             --disable-threads             &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>:            This switch will install the files into that
+#                            directory.
 # --with-sysroot:            This switch tells the build system to treat
 #                            /opt/[...] as the root directory.
 # --target=i686-w64-mingw32: This switch tells the compiler to target the Win32

--- a/scripts/004-mingw-x86.sh
+++ b/scripts/004-mingw-x86.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs the MinGW C Runtime.
 
-VERSION=13.0.0
 ARCHITECTURE=x86
-PACKAGE=mingw64-$ARCHITECTURE-mingw_w64-$VERSION
+PACKAGE=mingw64-$ARCHITECTURE-mingw_w64-$MINGW_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Make sure that we use our new utilities
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/bin:$PATH
+export PATH=$MINGW_OPT-i686/bin:$PATH
 
-tar -xvf ../mingw-w64-v$VERSION.tar.bz2
-cd       mingw-w64-v$VERSION
+tar -xvf ../mingw-w64-v$MINGW_V.tar.bz2
+cd          mingw-w64-v$MINGW_V
 
 # Configure the package. Explanations of the options will come after configure.
-./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/i686-w64-mingw32 \
-            --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686            \
-            --host=i686-w64-mingw32                                                  \
-            --disable-lib64                                                          \
-            --with-default-msvcrt=msvcrt                                             &&
+./configure --prefix=$MINGW_OPT-i686/i686-w64-mingw32 \
+            --with-sysroot=$MINGW_OPT-i686            \
+            --host=i686-w64-mingw32                   \
+            --disable-lib64                           \
+            --with-default-msvcrt=msvcrt             &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --with-sysroot: This switch tells the build system to treat /opt/[...] as
 #                 the root directory.
 # --host=i686-w64-mingw32: This uses the cross compiler that we just built.

--- a/scripts/005-mingw-winpthreads-x86.sh
+++ b/scripts/005-mingw-winpthreads-x86.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs the winpthreads library for GCC. It needs to be done
 # after MinGW, but before GCC.
 
-VERSION=13.0.0
 ARCHITECTURE=x86
-PACKAGE=mingw64-$ARCHITECTURE-mingw_w64-winpthreads-$VERSION
+PACKAGE=mingw64-$ARCHITECTURE-mingw_w64-winpthreads-$MINGW_PTHREAD_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Make sure that we use our new utilities
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/bin:$PATH
+export PATH=$MINGW_OPT-i686/bin:$PATH
 
-tar -xvf ../mingw-w64-v$VERSION.tar.bz2
-cd       mingw-w64-v$VERSION/mingw-w64-libraries/winpthreads
+tar -xvf ../mingw-w64-v$MINGW_PTHREAD_V.tar.bz2
+cd          mingw-w64-v$MINGW_PTHREAD_V/mingw-w64-libraries/winpthreads
 
 # Configure the package. Explanations of the options will come after configure.
-./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/i686-w64-mingw32 \
-            --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686            \
-            --host=i686-w64-mingw32                                                  \
-            --disable-lib64                                                          \
-            --with-default-msvcrt=msvcrt                                             &&
+./configure --prefix=$MINGW_OPT-i686/i686-w64-mingw32 \
+            --with-sysroot=$MINGW_OPT-i686            \
+            --host=i686-w64-mingw32                   \
+            --disable-lib64                           \
+            --with-default-msvcrt=msvcrt             &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --with-sysroot: This switch tells the build system to treat /opt/[...] as
 #                 the root directory.
 # --host=i686-w64-mingw32: This uses the cross compiler that we just built.

--- a/scripts/006-gcc-x86.sh
+++ b/scripts/006-gcc-x86.sh
@@ -1,51 +1,48 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs the final version of GCC, which should also use the
 # libraries installed in the last package.
 
-VERSION=15.1.0
 ARCHITECTURE=x86
-PACKAGE=mingw64-$ARCHITECTURE-gcc-final-$VERSION
-GMP_VERSION=6.3.0
-MPFR_VERSION=4.2.2
-MPC_VERSION=1.3.1
+PACKAGE=mingw64-$ARCHITECTURE-gcc-final-$GCC_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Extract the tarball and change into the directory.
-tar -xvf ../gcc-$VERSION.tar.xz
-cd       gcc-$VERSION
+tar -xvf ../gcc-$GCC_V.tar.xz
+cd          gcc-$GCC_V
 
 # Make sure that we use our new utilities
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/bin:$PATH
+export PATH=$MINGW_OPT-i686/bin:$PATH
 
 # Building GCC requires GMP, MPFR, and MPC. Let's have the build system build them.
-tar -xvf ../../gmp-$GMP_VERSION.tar.xz
-tar -xvf ../../mpc-$MPC_VERSION.tar.gz
-tar -xvf ../../mpfr-$MPFR_VERSION.tar.xz
-mv -v gmp-$GMP_VERSION/ gmp
-mv -v mpfr-$MPFR_VERSION/ mpfr/
-mv -v mpc-$MPC_VERSION/ mpc/
+tar -xvf ../../gmp-$GMP_V.tar.xz
+tar -xvf ../../mpc-$MPC_V.tar.gz
+tar -xvf ../../mpfr-$MPFR_V.tar.xz
+mv -v gmp-$GMP_V   gmp
+mv -v mpfr-$MPFR_V mpfr
+mv -v mpc-$MPC_V   mpc
 
 # Create a directory outside of the source tree.
 
 mkdir build
 cd    build
 
-../configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686 \
-             --target=i686-w64-mingw32                               \
-             --enable-languages=c,c++                                \
-             --enable-shared                                         \
-             --disable-multilib                                      \
-             --with-arch=i486                                        \
-             --with-tune=i486                                        \
-             --disable-bootstrap                                     \
-             --enable-threads=posix                                  \
-             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686 &&
+../configure --prefix=$MINGW_OPT-i686  \
+             --target=i686-w64-mingw32 \
+             --enable-languages=c,c++  \
+             --enable-shared           \
+             --disable-multilib        \
+             --with-arch=i486          \
+             --with-tune=i486          \
+             --disable-bootstrap       \
+             --enable-threads=posix    \
+             --with-sysroot=$MINGW_OPT-i686 &&
 
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --target=i686-w64-mingw32: This switch tells the compiler to target the Win32
 #                            architecture.
 # --enable-languages=c,c++:  We only need the C and C++ languages to be built.

--- a/scripts/007-headers-install-x86_64.sh
+++ b/scripts/007-headers-install-x86_64.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # The first package that we need to install is the MinGW Headers. These headers
 # contain an implementation of the Win32 API.
 
-VERSION=13.0.0
 ARCHITECTURE=x86_64
-PACKAGE=mingw64-$ARCHITECTURE-headers-$VERSION
+PACKAGE=mingw64-$ARCHITECTURE-headers-$MINGW_HEADER_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Extract the tarball and change into the directory.
-tar -xvf ../mingw-w64-v$VERSION.tar.bz2
-cd          mingw-w64-v$VERSION
+tar -xvf ../mingw-w64-v$MINGW_HEADER_V.tar.bz2
+cd          mingw-w64-v$MINGW_HEADER_V
 
 # The source requires that we build it outside of the source tree. We'll work
 # around this by creating a separete directory and changing into it.
@@ -21,13 +21,13 @@ mkdir build-x86_64-headers
 cd    build-x86_64-headers
 
 # Configure the headers. Explanations of the options will come after configure.
-../mingw-w64-headers/configure                                                 \
-  --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/x86_64-w64-mingw32 \
-  --enable-sdk=all                                                             \
-  --host=x86_64-w64-mingw32                                                    \
+../mingw-w64-headers/configure                  \
+  --prefix=$MINGW_OPT-x86_64/x86_64-w64-mingw32 \
+  --enable-sdk=all                              \
+  --host=x86_64-w64-mingw32                     \
   --with-default-msvcrt=msvcrt
 
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --enable-sdk=all: Installs all of the headers for MinGW.
 # --host=x86_64-w64-mingw32: Builds files for the x86_64 version of MinGW.
 # --with-default-msvcrt: Selects the default Visual C++ Runtime as the

--- a/scripts/008-binutils-x86_64.sh
+++ b/scripts/008-binutils-x86_64.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs Binutils, which includes a linker and support programs.
 
-VERSION=2.44
 ARCHITECTURE=x86_64
-PACKAGE=mingw64-$ARCHITECTURE-binutils-$VERSION
+PACKAGE=mingw64-$ARCHITECTURE-binutils-$BINUTILS_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Extract the tarball and change into the directory.
-tar -xvf ../binutils-$VERSION.tar.xz
-cd       binutils-$VERSION
+tar -xvf ../binutils-$BINUTILS_V.tar.xz
+cd          binutils-$BINUTILS_V
 
 # This project needs to be built outside of it's source tree. We'll accomodate
 # that by making a new directory and changing into it.
@@ -20,14 +20,14 @@ mkdir build
 cd    build
 
 # First we'll configure Binutils.
-../configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64       \
-             --target=x86_64-w64-mingw32                                     \
-             --disable-nls                                                   \
-             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64 \
-             --disable-werror                                                &&
+../configure --prefix=$MINGW_OPT-x86_64       \
+             --target=x86_64-w64-mingw32      \
+             --disable-nls                    \
+             --with-sysroot=$MINGW_OPT-x86_64 \
+             --disable-werror                &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --target=x86_64-w64-mingw32: This outputs files targeting the x86_64 version
 #                              of MinGW.
 # --disable-nls:      This switch disables installing files that allow for
@@ -44,10 +44,10 @@ make -j4 &&
 sudo make install
 
 # Remove an unnecessary library
-sudo rm -v /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/lib/bfd-plugins/libdep.so
+sudo rm -v $MINGW_OPT-x86_64/lib/bfd-plugins/libdep.so
 
 # GCC requires a symlink of 'mingw' to be a mirror of the x86_64-w64-mingw32
 # directory, and it needs to be in the same root.
-cd /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64
+cd $MINGW_OPT-x86_64
 sudo ln -sfv ./x86_64-w64-mingw32 ./mingw
 sudo ln -sfv ./mingw/include include

--- a/scripts/009-gcc-static-x86_64.sh
+++ b/scripts/009-gcc-static-x86_64.sh
@@ -1,50 +1,47 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs a static version of GCC. This is needed because we do
 # not have a copy of the MinGW C Runtime installed yet, but we still need a
 # way to compile it.
 
-VERSION=15.1.0
 ARCHITECTURE=x86_64
-PACKAGE=mingw64-$ARCHITECTURE-gcc-static-$VERSION
-GMP_VERSION=6.3.0
-MPFR_VERSION=4.2.2
-MPC_VERSION=1.3.1
+PACKAGE=mingw64-$ARCHITECTURE-gcc-static-$GCC_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Make sure that we use our new utilities from binutils
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/bin:$PATH
+export PATH=$MINGW_OPT-x86_64/bin:$PATH
 
 # Extract the tarball and change into the directory.
-tar -xvf ../gcc-$VERSION.tar.xz
-cd       gcc-$VERSION
+tar -xvf ../gcc-$GCC_V.tar.xz
+cd          gcc-$GCC_V
 
 # Building GCC requires GMP, MPFR, and MPC. Let's have the build system build them.
-tar -xvf ../../gmp-$GMP_VERSION.tar.xz
-tar -xvf ../../mpc-$MPC_VERSION.tar.gz
-tar -xvf ../../mpfr-$MPFR_VERSION.tar.xz
-mv -v gmp-$GMP_VERSION/ gmp
-mv -v mpfr-$MPFR_VERSION/ mpfr/
-mv -v mpc-$MPC_VERSION/ mpc/
+tar -xvf ../../gmp-$GMP_V.tar.xz
+tar -xvf ../../mpc-$MPC_V.tar.gz
+tar -xvf ../../mpfr-$MPFR_V.tar.xz
+mv -v gmp-$GMP_V   gmp
+mv -v mpfr-$MPFR_V mpfr
+mv -v mpc-$MPC_V   mpc
 
 # Create a directory outside of the source tree.
 
 mkdir build
 cd    build
 
-../configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64       \
-             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64 \
-             --target=x86_64-w64-mingw32                                     \
-             --enable-languages=c,c++                                        \
-             --disable-shared                                                \
-             --disable-multilib                                              \
-             --disable-threads                                               &&
+../configure --prefix=$MINGW_OPT-x86_64       \
+             --with-sysroot=$MINGW_OPT-x86_64 \
+             --target=x86_64-w64-mingw32      \
+             --enable-languages=c,c++         \
+             --disable-shared                 \
+             --disable-multilib               \
+             --disable-threads               &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --with-sysroot:            This switch tells the build system to treat
 #                            /opt/[...] as the root directory.
 # --target=x86_64-w64-mingw32: This switch tells the compiler to target the Win32

--- a/scripts/010-mingw-x86_64.sh
+++ b/scripts/010-mingw-x86_64.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs the MinGW C Runtime.
 
-VERSION=13.0.0
 ARCHITECTURE=x86_64
-PACKAGE=mingw64-$ARCHITECTURE-mingw_w64-$VERSION
+PACKAGE=mingw64-$ARCHITECTURE-mingw_w64-$MINGW_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Make sure that we use our new utilities
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/bin:$PATH
+export PATH=$MINGW_OPT-x86_64/bin:$PATH
 
-tar -xvf ../mingw-w64-v$VERSION.tar.bz2
-cd       mingw-w64-v$VERSION
+tar -xvf ../mingw-w64-v$MINGW_V.tar.bz2
+cd          mingw-w64-v$MINGW_V
 
 # Configure the package. Explanations of the options will come after configure.
-./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/x86_64-w64-mingw32 \
-            --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64              \
-            --host=x86_64-w64-mingw32                                                    \
-            --disable-lib32                                                              \
-            --with-default-msvcrt=msvcrt                                                 &&
+./configure --prefix=$MINGW_OPT-x86_64/x86_64-w64-mingw32 \
+            --with-sysroot=$MINGW_OPT-x86_64              \
+            --host=x86_64-w64-mingw32                     \
+            --disable-lib32                               \
+            --with-default-msvcrt=msvcrt                 &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --with-sysroot: This switch tells the build system to treat /opt/[...] as
 #                 the root directory.
 # --host=x86_64-w64-mingw32: This uses the cross compiler that we just built.

--- a/scripts/011-mingw-winpthreads-x86_64.sh
+++ b/scripts/011-mingw-winpthreads-x86_64.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs the winpthreads library for GCC. It needs to be done
 # after MinGW, but before GCC.
 
-VERSION=13.0.0
 ARCHITECTURE=x86_64
-PACKAGE=mingw64-$ARCHITECTURE-mingw_w64-winpthreads-$VERSION
+PACKAGE=mingw64-$ARCHITECTURE-mingw_w64-winpthreads-$MINGW_PTHREAD_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Make sure that we use our new utilities
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/bin:$PATH
+export PATH=$MINGW_OPT-x86_64/bin:$PATH
 
-tar -xvf ../mingw-w64-v$VERSION.tar.bz2
-cd       mingw-w64-v$VERSION/mingw-w64-libraries/winpthreads
+tar -xvf ../mingw-w64-v$MINGW_PTHREAD_V.tar.bz2
+cd          mingw-w64-v$MINGW_PTHREAD_V/mingw-w64-libraries/winpthreads
 
 # Configure the package. Explanations of the options will come after configure.
-./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/x86_64-w64-mingw32 \
-            --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64              \
-            --host=x86_64-w64-mingw32                                                    \
-            --disable-lib32                                                              \
-            --with-default-msvcrt=msvcrt                                                 &&
+./configure --prefix=$MINGW_OPT-x86_64/x86_64-w64-mingw32 \
+            --with-sysroot=$MINGW_OPT-x86_64              \
+            --host=x86_64-w64-mingw32                     \
+            --disable-lib32                               \
+            --with-default-msvcrt=msvcrt                 &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --with-sysroot: This switch tells the build system to treat /opt/[...] as
 #                 the root directory.
 # --host=x86_64-w64-mingw32: This uses the cross compiler that we just built.

--- a/scripts/012-gcc-x86_64.sh
+++ b/scripts/012-gcc-x86_64.sh
@@ -1,49 +1,46 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script installs the final version of GCC, which should also use the
 # libraries installed in the last package.
 
-VERSION=15.1.0
 ARCHITECTURE=x86_64
-PACKAGE=mingw64-$ARCHITECTURE-gcc-final-$VERSION
-GMP_VERSION=6.3.0
-MPFR_VERSION=4.2.2
-MPC_VERSION=1.3.1
+PACKAGE=mingw64-$ARCHITECTURE-gcc-final-$GCC_V
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Extract the tarball and change into the directory.
-tar -xvf ../gcc-$VERSION.tar.xz
-cd       gcc-$VERSION
+tar -xvf ../gcc-$GCC_V.tar.xz
+cd          gcc-$GCC_V
 
 # Make sure that we use our new utilities
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/bin:$PATH
+export PATH=$MINGW_OPT-x86_64/bin:$PATH
 
 # Building GCC requires GMP, MPFR, and MPC. Let's have the build system build them.
-tar -xvf ../../gmp-$GMP_VERSION.tar.xz
-tar -xvf ../../mpc-$MPC_VERSION.tar.gz
-tar -xvf ../../mpfr-$MPFR_VERSION.tar.xz
-mv -v gmp-$GMP_VERSION/ gmp
-mv -v mpfr-$MPFR_VERSION/ mpfr/
-mv -v mpc-$MPC_VERSION/ mpc/
+tar -xvf ../../gmp-$GMP_V.tar.xz
+tar -xvf ../../mpc-$MPC_V.tar.gz
+tar -xvf ../../mpfr-$MPFR_V.tar.xz
+mv -v gmp-$GMP_V   gmp
+mv -v mpfr-$MPFR_V mpfr
+mv -v mpc-$MPC_V   mpc
 
 # Create a directory outside of the source tree.
 
 mkdir build
 cd    build
 
-../configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64 \
-             --target=x86_64-w64-mingw32                               \
-             --enable-languages=c,c++                                  \
-             --enable-shared                                           \
-             --disable-multilib                                        \
-             --disable-bootstrap                                       \
-             --enable-threads=posix                                    \
-             --with-sysroot=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64 &&
+../configure --prefix=$MINGW_OPT-x86_64        \
+             --target=x86_64-w64-mingw32       \
+             --enable-languages=c,c++          \
+             --enable-shared                   \
+             --disable-multilib                \
+             --disable-bootstrap               \
+             --enable-threads=posix            \
+             --with-sysroot=$MINGW_OPT-x86_64 &&
 
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # --target=x86_64-w64-mingw32: This switch tells the compiler to target the Win32
 #                              architecture.
 # --enable-languages=c,c++:  We only need the C and C++ languages to be built.

--- a/scripts/013-zlib-x86.sh
+++ b/scripts/013-zlib-x86.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script builds a copy of zlib for MinGW. We need this to compile a new
 # version of NSIS.
 
-VERSION=1.3.1
 ARCHITECTURE=x86
-PACKAGE=mingw64-$ARCHITECTURE-zlib-$VERSION
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/bin:$PATH
+PACKAGE=mingw64-$ARCHITECTURE-zlib-$ZLIB_V
+export PATH=$MINGW_OPT-i686/bin:$PATH
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Extract the tarball and change into the directory.
-tar -xvf ../zlib-$VERSION.tar.gz
-cd       zlib-$VERSION
+tar -xvf ../zlib-$ZLIB_V.tar.gz
+cd          zlib-$ZLIB_V
 
 # First, tell the zlib build system to use the MinGW version of dllwrap.
 sed -i -e "s/dllwrap/i686-w64-mingw32-dllwrap/" win32/Makefile.gcc
 
 # Configure the build. Explanations of the options will come after configure.
-CC=i686-w64-mingw32-gcc                                             \
-./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686 \
-            -shared                                                 \
-            -static                                                 &&
+CC=i686-w64-mingw32-gcc              \
+./configure --prefix=$MINGW_OPT-i686 \
+            -shared                  \
+            -static                 &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # -shared and -static: Builds both static and shared versions of zlib.
 
 # --- Compilation and installation instructions go here ---
@@ -39,7 +39,7 @@ STRIP="i686-w64-mingw32-strip" \
 IMPLIB=libz.dll.a              &&
 
 # Install zlib into the toolchain
-sudo cp -v zlib.h zconf.h /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/include
-sudo cp -v libz.a libz.dll.a /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/lib
-sudo mkdir -pv /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/lib/pkgconfig
-sudo cp -v zlib.pc /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/lib/pkgconfig
+sudo cp -v zlib.h zconf.h    $MINGW_OPT-i686/include
+sudo cp -v libz.a libz.dll.a $MINGW_OPT-i686/lib
+sudo mkdir -pv               $MINGW_OPT-i686/lib/pkgconfig
+sudo cp -v zlib.pc           $MINGW_OPT-i686/lib/pkgconfig

--- a/scripts/014-zlib-x86_64.sh
+++ b/scripts/014-zlib-x86_64.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # This script builds a copy of zlib for MinGW. We need this to compile a new
 # version of NSIS.
 
-VERSION=1.3.1
 ARCHITECTURE=x86_64
-PACKAGE=mingw64-$ARCHITECTURE-zlib-$VERSION
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/bin:$PATH
+PACKAGE=mingw64-$ARCHITECTURE-zlib-$ZLIB_V
+export PATH=$MINGW_OPT-x86_64/bin:$PATH
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Extract the tarball and change into the directory.
-tar -xvf ../zlib-$VERSION.tar.gz
-cd       zlib-$VERSION
+tar -xvf ../zlib-$ZLIB_V.tar.gz
+cd          zlib-$ZLIB_V
 
 # First, tell the zlib build system to use the MinGW version of dllwrap.
 sed -i -e "s/dllwrap/x86_64-w64-mingw32-dllwrap/" win32/Makefile.gcc
 
 # Configure the build. Explanations of the options will come after configure.
-CC=x86_64-w64-mingw32-gcc                                             \
-./configure --prefix=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64 \
-            -shared                                                   \
-            -static                                                   &&
+CC=x86_64-w64-mingw32-gcc              \
+./configure --prefix=$MINGW_OPT-x86_64 \
+            -shared                    \
+            -static                   &&
 
 # --- Descriptions go here ---
-# --prefix=/opt/*: This switch will install the files into that directory.
+# --prefix=<...>: This switch will install the files into that directory.
 # -shared and -static: Builds both static and shared versions of zlib.
 
 # --- Compilation and installation instructions go here ---
@@ -39,7 +39,7 @@ STRIP="x86_64-w64-mingw32-strip" \
 IMPLIB=libz.dll.a                &&
 
 # Install zlib into the toolchain
-sudo cp -v zlib.h zconf.h /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/include
-sudo cp -v libz.a libz.dll.a /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/lib
-sudo mkdir -pv /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/lib/pkgconfig
-sudo cp -v zlib.pc /opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/lib/pkgconfig
+sudo cp -v zlib.h zconf.h    $MINGW_OPT-x86_64/include
+sudo cp -v libz.a libz.dll.a $MINGW_OPT-x86_64/lib
+sudo mkdir -pv               $MINGW_OPT-x86_64/lib/pkgconfig
+sudo cp -v zlib.pc           $MINGW_OPT-x86_64/lib/pkgconfig

--- a/scripts/015-nsis.sh
+++ b/scripts/015-nsis.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
+source $(dirname "$0")/variables.in
 
 # We need a copy of NSIS to fix a security vulnerability in the version of NSIS
 # that Ubuntu 24.04 ships with.
 
-VERSION=3.11
-PACKAGE=nsis-$VERSION-src
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/bin:$PATH
-export PATH=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-x86_64/bin:$PATH
+PACKAGE=nsis-$NSIS_V-src
+export PATH=$MINGW_OPT-i686/bin:$PATH
+export PATH=$MINGW_OPT-x86_64/bin:$PATH
 
 # Create a separate scratch directory and change into it.
-mkdir    $PACKAGE
-cd       $PACKAGE
+mkdir $PACKAGE
+cd    $PACKAGE
 
 # Extract the tarball and change into the directory.
 tar -xvf ../$PACKAGE.tar.bz2
-cd       $PACKAGE
+cd          $PACKAGE
 
 # This package uses SCons as it's build system, which requires all of the
 # configuration options to be set as variables.
@@ -22,18 +22,18 @@ cd       $PACKAGE
 # Compile the package. Note that we skip the NSIS Menu utility because it needs
 # WxWidgets.
 
-scons VERSION=$VERSION                   \
-      PREFIX=/opt/nsis-$VERSION          \
-      PREFIX_CONF=/opt/nsis-$VERSION/etc \
-      SKIPUTILS="NSIS Menu"              \
-      STRIP_CP=false                     \
-      NSIS_MAX_STRLEN=8192               \
-      ZLIB_W32=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/lib &&
+scons VERSION=$NSIS_V                   \
+      PREFIX=/opt/nsis-$NSIS_V          \
+      PREFIX_CONF=/opt/nsis-$NSIS_V/etc \
+      SKIPUTILS="NSIS Menu"             \
+      STRIP_CP=false                    \
+      NSIS_MAX_STRLEN=8192              \
+      ZLIB_W32=$MINGW_OPT-i686/lib &&
 
-sudo scons VERSION=$VERSION                   \
-           PREFIX=/opt/nsis-$VERSION          \
-           PREFIX_CONF=/opt/nsis-$VERSION/etc \
-           SKIPUTILS="NSIS Menu"              \
-           STRIP_CP=false                     \
-           NSIS_MAX_STRLEN=8192               \
-           ZLIB_W32=/opt/gcc-15.1-binutils-2.44-mingw-v13.0.0-i686/lib install
+sudo scons VERSION=$NSIS_V                   \
+           PREFIX=/opt/nsis-$NSIS_V          \
+           PREFIX_CONF=/opt/nsis-$NSIS_V/etc \
+           SKIPUTILS="NSIS Menu"             \
+           STRIP_CP=false                    \
+           NSIS_MAX_STRLEN=8192              \
+           ZLIB_W32=$MINGW_OPT-i686/lib install

--- a/scripts/variables.in
+++ b/scripts/variables.in
@@ -1,0 +1,16 @@
+# When updating package versions, don't forget to update README.md accordingly.
+# The scripts won't need to be updated unless a package update calls for a
+# needed adjustment.
+
+MINGW_V=13.0.0
+MINGW_HEADER_V=$MINGW_V
+BINUTILS_V=2.44
+GCC_MIN_V=15.1
+GCC_V=$GCC_MIN_V.0
+GMP_V=6.3.0
+MPFR_V=4.2.2
+MPC_V=1.3.1
+MINGW_PTHREAD_V=$MINGW_V
+ZLIB_V=1.3.1
+NSIS_V=3.11
+MINGW_OPT=/opt/gcc-$GCC_MIN_V-binutils-$BINUTILS_V-mingw-v$MINGW_V


### PR DESCRIPTION
This makes updating any packages in the toolchain less of a burden by offloading all the package versions as variables into one single file that gets sourced by each script. This in turn allows for a single prefix for the opt directory that is shared between each architecture, which then will differ further in each script, but will no longer contain any package versions. At that point, it's arch-specific.

An important note is that while the scripts for the most part won't have to get updated whenever a package is updated in the toolchain besides the actual variables.in file, README.md must be updated everytime. Markdown doesn't support variables, so we will have to offload the version-specific instructions to another/more script(s) if we want to get around that.

Tested all scripts besides 015-nsis.sh due to a lack of scons. Everything else results in a working toolchain for both architectures.